### PR TITLE
Update editors.markdown

### DIFF
--- a/jekyll/editors.markdown
+++ b/jekyll/editors.markdown
@@ -222,15 +222,17 @@ appropriate command for your Ruby version manager as an absolute path. For examp
 return {
   {
     "neovim/nvim-lspconfig",
+    opts = {
       servers = {
         ruby_lsp = {
           mason = false,
-          cmd = { vim.fn.expand "~/.asdf/shims/ruby-lsp" },
+          cmd = { vim.fn.expand("~/.asdf/shims/ruby-lsp") },
         },
       },
     },
   },
 }
+
 ```
 
 ## Sublime Text LSP


### PR DESCRIPTION


### Motivation

Fix configuration for Lazyvim by wrapping the `servers` table within the `opts` table.

When I tested this on my Lazyvim installation, the configuration did not work as documented. However, once I updated the config to be wrapped in the `opts` table, the LSP was loaded successfully.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
